### PR TITLE
Potential fix for code scanning alert no. 8: Replacement of a substring with itself

### DIFF
--- a/apps/webapp/src/routes/register.tsx
+++ b/apps/webapp/src/routes/register.tsx
@@ -305,7 +305,7 @@ function RouteComponent() {
                       {
                         link: '',
                       },
-                    ).replace('', '')}
+                    )}
                     <Anchor href="https://guallet.io">
                       {t(
                         'screens.register.form.termsLink',


### PR DESCRIPTION
Potential fix for [https://github.com/Guallet/monorepo/security/code-scanning/8](https://github.com/Guallet/monorepo/security/code-scanning/8)

In general, to fix this issue you should remove or correct any string replacement that replaces a substring with itself, especially when the substring is the empty string. If the original intent was to substitute a placeholder, use either proper interpolation through the i18n library or JSX composition; if there was no intent, simply delete the redundant call.

For this specific case in `apps/webapp/src/routes/register.tsx`, the best fix that does not change existing functionality is to remove the `.replace('', '')` on line 308. The `t(...)` call already returns the correct label ("Agree the {{link}}." or its localized equivalent), and the link is being rendered as a separate `<Anchor>` component immediately after it. Removing `.replace('', '')` leaves the displayed text unchanged (since it was a no-op) while eliminating the CodeQL-detected issue and making the code clearer.

Only a single code edit is needed in this file: delete the `.replace('', '')` call from the expression that renders the terms agreement text. No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
