### PR TITLE
feat(api): enhanced health check service with Redis and database checks

### DIFF
--- a/apps/api/src/features/health/health.constants.ts
+++ b/apps/api/src/features/health/health.constants.ts
@@ -1,0 +1,1 @@
+export const HEALTH_CHECK_QUEUE = 'health-check';

--- a/apps/api/src/features/health/health.module.ts
+++ b/apps/api/src/features/health/health.module.ts
@@ -1,8 +1,15 @@
 import { Module } from '@nestjs/common';
+import { BullModule } from '@nestjs/bullmq';
 import { HealthController } from './health.controller';
 import { HealthService } from './health.service';
+import { HEALTH_CHECK_QUEUE } from './health.constants';
 
 @Module({
+  imports: [
+    BullModule.registerQueue({
+      name: HEALTH_CHECK_QUEUE,
+    }),
+  ],
   controllers: [HealthController],
   providers: [HealthService],
 })

--- a/apps/api/src/features/health/health.service.ts
+++ b/apps/api/src/features/health/health.service.ts
@@ -1,11 +1,80 @@
 import { Injectable } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import { DataSource } from 'typeorm';
+import { HEALTH_CHECK_QUEUE } from './health.constants';
+
+export type CheckStatus = 'up' | 'down';
+
+export interface HealthCheckResult {
+  status: CheckStatus;
+  latencyMs: number;
+  error?: string;
+}
 
 @Injectable()
 export class HealthService {
-  check() {
+  constructor(
+    private readonly dataSource: DataSource,
+    @InjectQueue(HEALTH_CHECK_QUEUE)
+    private readonly healthCheckQueue: Queue,
+  ) {}
+
+  async check() {
+    const [database, redis] = await Promise.all([
+      this.checkDatabase(),
+      this.checkRedis(),
+    ]);
+
+    const status: 'ok' | 'degraded' =
+      database.status === 'up' && redis.status === 'up' ? 'ok' : 'degraded';
+
     return {
-      status: 'ok',
+      status,
       timestamp: new Date().toISOString(),
+      checks: {
+        database,
+        redis,
+      },
     };
+  }
+
+  private async checkDatabase(): Promise<HealthCheckResult> {
+    const start = Date.now();
+
+    try {
+      await this.dataSource.query('SELECT 1');
+
+      return {
+        status: 'up',
+        latencyMs: Date.now() - start,
+      };
+    } catch (error) {
+      return {
+        status: 'down',
+        latencyMs: Date.now() - start,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  private async checkRedis(): Promise<HealthCheckResult> {
+    const start = Date.now();
+
+    try {
+      const redisClient = await this.healthCheckQueue.client;
+      await redisClient.ping();
+
+      return {
+        status: 'up',
+        latencyMs: Date.now() - start,
+      };
+    } catch (error) {
+      return {
+        status: 'down',
+        latencyMs: Date.now() - start,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
   }
 }


### PR DESCRIPTION
This pull request enhances the health check functionality by introducing detailed checks for both the database and Redis, and by integrating BullMQ for queue-based health monitoring. The changes improve the reliability and observability of the health status endpoint by providing granular status and latency metrics.

**Health check improvements:**

* The `HealthService` now performs separate, asynchronous checks for the database and Redis, returning detailed status and latency information for each. The overall health status is set to `'ok'` only if both checks pass; otherwise, it is `'degraded'`.
* New types and interfaces (`CheckStatus`, `HealthCheckResult`) are introduced to standardize health check results.

**BullMQ integration:**

* The `BullModule` is now imported and configured in `health.module.ts` to register a dedicated health check queue using the constant `HEALTH_CHECK_QUEUE`. [[1]](diffhunk://#diff-5a29e6922f6fda6e778b60bb88db574e6ed3f308bdc28bb5e4b7c77674d0dd47R2-R12) [[2]](diffhunk://#diff-2cc545a738bfec74fe3f4d04ee5ce1245e63721b1a0ac571884a5403340495beR1)
* The `HealthService` uses BullMQ's queue client to perform a Redis health check via the `ping()` command, ensuring the Redis connection is actively monitored.

**Constants and configuration:**

* A new constant `HEALTH_CHECK_QUEUE` is defined in `health.constants.ts` to centralize the queue name configuration.